### PR TITLE
Require minitest before undef methods

### DIFF
--- a/count/count_test.rb
+++ b/count/count_test.rb
@@ -1,3 +1,4 @@
+require 'minitest/autorun'
 class Array
   undef count
 end
@@ -6,7 +7,6 @@ module Enumerable
   undef count
 end
 
-require 'minitest/autorun'
 require_relative 'count'
 
 class CountTest < MiniTest::Test

--- a/partition/partition_test.rb
+++ b/partition/partition_test.rb
@@ -1,8 +1,8 @@
+require 'minitest/autorun'
 module Enumerable
   undef partition
 end
 
-require 'minitest/autorun'
 require_relative 'partition'
 
 class PartitionTest < MiniTest::Test

--- a/predicates/predicates_test.rb
+++ b/predicates/predicates_test.rb
@@ -1,8 +1,8 @@
+require 'minitest/autorun'
 class Array
   undef all?, any?, include?, one?, none?
 end
 
-require 'minitest/autorun'
 require_relative 'predicates'
 
 class PredicatesTest < MiniTest::Test

--- a/sum/sum_test.rb
+++ b/sum/sum_test.rb
@@ -1,8 +1,8 @@
+require 'minitest/autorun'
 module Enumerable
   undef sum
 end
 
-require 'minitest/autorun'
 require_relative 'sum'
 
 class SumTest < MiniTest::Test

--- a/uniq/uniq_test.rb
+++ b/uniq/uniq_test.rb
@@ -1,3 +1,4 @@
+require 'minitest/autorun'
 class Array
   undef uniq
 end
@@ -6,7 +7,6 @@ module Enumerable
   undef uniq
 end
 
-require 'minitest/autorun'
 require_relative 'uniq'
 
 class UniqTest < MiniTest::Test


### PR DESCRIPTION
It makes test cases fail properly.